### PR TITLE
feat: lazy stack trace capture with deferred symbolization

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ true
 
 ## Index
 
+- [Constants](<#constants>)
 - [func SetBaseFilePath\(path string\)](<#SetBaseFilePath>)
 - [func SetMaxStackDepth\(n int\)](<#SetMaxStackDepth>)
 - [type ErrorExt](<#ErrorExt>)
@@ -124,8 +125,16 @@ true
 - [type StackFrame](<#StackFrame>)
 
 
+## Constants
+
+<a name="SupportPackageIsVersion1"></a>SupportPackageIsVersion1 is a compile\-time assertion constant. Downstream packages reference this to enforce version compatibility.
+
+```go
+const SupportPackageIsVersion1 = true
+```
+
 <a name="SetBaseFilePath"></a>
-## func [SetBaseFilePath](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L257>)
+## func [SetBaseFilePath](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L278>)
 
 ```go
 func SetBaseFilePath(path string)
@@ -134,16 +143,16 @@ func SetBaseFilePath(path string)
 SetBaseFilePath sets the base file path for linking source code with reported stack information
 
 <a name="SetMaxStackDepth"></a>
-## func [SetMaxStackDepth](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L240>)
+## func [SetMaxStackDepth](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L261>)
 
 ```go
 func SetMaxStackDepth(n int)
 ```
 
-SetMaxStackDepth sets the maximum number of stack frames captured when creating errors. Default is 64. Must be called during initialization.
+SetMaxStackDepth sets the maximum number of stack frames captured when creating errors. Default is 16. Safe for concurrent use.
 
 <a name="ErrorExt"></a>
-## type [ErrorExt](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L26-L37>)
+## type [ErrorExt](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L34-L45>)
 
 ErrorExt is the interface that defines a error, any ErrorExt implementors can use and override errors and notifier package
 
@@ -163,7 +172,7 @@ type ErrorExt interface {
 ```
 
 <a name="New"></a>
-### func [New](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L156>)
+### func [New](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L178>)
 
 ```go
 func New(msg string) ErrorExt
@@ -201,7 +210,7 @@ something went wrong
 </details>
 
 <a name="NewWithSkip"></a>
-### func [NewWithSkip](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L166>)
+### func [NewWithSkip](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L188>)
 
 ```go
 func NewWithSkip(msg string, skip int) ErrorExt
@@ -210,7 +219,7 @@ func NewWithSkip(msg string, skip int) ErrorExt
 NewWithSkip creates a new error skipping the number of function on the stack
 
 <a name="NewWithSkipAndStatus"></a>
-### func [NewWithSkipAndStatus](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L171>)
+### func [NewWithSkipAndStatus](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L193>)
 
 ```go
 func NewWithSkipAndStatus(msg string, skip int, status *grpcstatus.Status) ErrorExt
@@ -219,7 +228,7 @@ func NewWithSkipAndStatus(msg string, skip int, status *grpcstatus.Status) Error
 NewWithSkipAndStatus creates a new error skipping the number of function on the stack and GRPC status
 
 <a name="NewWithStatus"></a>
-### func [NewWithStatus](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L161>)
+### func [NewWithStatus](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L183>)
 
 ```go
 func NewWithStatus(msg string, status *grpcstatus.Status) ErrorExt
@@ -228,7 +237,7 @@ func NewWithStatus(msg string, status *grpcstatus.Status) ErrorExt
 NewWithStatus creates a new error with statck information and GRPC status
 
 <a name="Newf"></a>
-### func [Newf](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L247>)
+### func [Newf](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L268>)
 
 ```go
 func Newf(format string, args ...any) ErrorExt
@@ -266,7 +275,7 @@ user alice not found
 </details>
 
 <a name="Wrap"></a>
-### func [Wrap](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L176>)
+### func [Wrap](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L198>)
 
 ```go
 func Wrap(err error, msg string) ErrorExt
@@ -340,7 +349,7 @@ true
 </details>
 
 <a name="WrapWithSkip"></a>
-### func [WrapWithSkip](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L186>)
+### func [WrapWithSkip](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L208>)
 
 ```go
 func WrapWithSkip(err error, msg string, skip int) ErrorExt
@@ -349,7 +358,7 @@ func WrapWithSkip(err error, msg string, skip int) ErrorExt
 WrapWithSkip wraps an existing error and appends stack information if it does not exists skipping the number of function on the stack
 
 <a name="WrapWithSkipAndStatus"></a>
-### func [WrapWithSkipAndStatus](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L191>)
+### func [WrapWithSkipAndStatus](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L213>)
 
 ```go
 func WrapWithSkipAndStatus(err error, msg string, skip int, status *grpcstatus.Status) ErrorExt
@@ -358,7 +367,7 @@ func WrapWithSkipAndStatus(err error, msg string, skip int, status *grpcstatus.S
 WrapWithSkip wraps an existing error and appends stack information if it does not exists skipping the number of function on the stack along with GRPC status
 
 <a name="WrapWithStatus"></a>
-### func [WrapWithStatus](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L181>)
+### func [WrapWithStatus](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L203>)
 
 ```go
 func WrapWithStatus(err error, msg string, status *grpcstatus.Status) ErrorExt
@@ -403,7 +412,7 @@ gRPC code: NotFound
 </details>
 
 <a name="Wrapf"></a>
-### func [Wrapf](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L252>)
+### func [Wrapf](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L273>)
 
 ```go
 func Wrapf(err error, format string, args ...any) ErrorExt
@@ -442,7 +451,7 @@ failed to connect to port 5432: connection refused
 </details>
 
 <a name="NotifyExt"></a>
-## type [NotifyExt](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L40-L45>)
+## type [NotifyExt](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L48-L53>)
 
 NotifyExt is the interface definition for notifier related options
 
@@ -456,7 +465,7 @@ type NotifyExt interface {
 ```
 
 <a name="StackFrame"></a>
-## type [StackFrame](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L19-L23>)
+## type [StackFrame](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L27-L31>)
 
 StackFrame represents the stackframe for tracing exception
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ const SupportPackageIsVersion1 = true
 ```
 
 <a name="SetBaseFilePath"></a>
-## func [SetBaseFilePath](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L278>)
+## func [SetBaseFilePath](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L281>)
 
 ```go
 func SetBaseFilePath(path string)
@@ -143,13 +143,13 @@ func SetBaseFilePath(path string)
 SetBaseFilePath sets the base file path for linking source code with reported stack information
 
 <a name="SetMaxStackDepth"></a>
-## func [SetMaxStackDepth](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L261>)
+## func [SetMaxStackDepth](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L264>)
 
 ```go
 func SetMaxStackDepth(n int)
 ```
 
-SetMaxStackDepth sets the maximum number of stack frames captured when creating errors. Default is 16. Safe for concurrent use.
+SetMaxStackDepth sets the maximum number of stack frames captured when creating errors. Accepts values in \[1, 256\]; out\-of\-range values are ignored. Default is 16. Safe for concurrent use.
 
 <a name="ErrorExt"></a>
 ## type [ErrorExt](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L34-L45>)
@@ -172,7 +172,7 @@ type ErrorExt interface {
 ```
 
 <a name="New"></a>
-### func [New](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L178>)
+### func [New](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L180>)
 
 ```go
 func New(msg string) ErrorExt
@@ -210,7 +210,7 @@ something went wrong
 </details>
 
 <a name="NewWithSkip"></a>
-### func [NewWithSkip](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L188>)
+### func [NewWithSkip](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L190>)
 
 ```go
 func NewWithSkip(msg string, skip int) ErrorExt
@@ -219,7 +219,7 @@ func NewWithSkip(msg string, skip int) ErrorExt
 NewWithSkip creates a new error skipping the number of function on the stack
 
 <a name="NewWithSkipAndStatus"></a>
-### func [NewWithSkipAndStatus](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L193>)
+### func [NewWithSkipAndStatus](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L195>)
 
 ```go
 func NewWithSkipAndStatus(msg string, skip int, status *grpcstatus.Status) ErrorExt
@@ -228,7 +228,7 @@ func NewWithSkipAndStatus(msg string, skip int, status *grpcstatus.Status) Error
 NewWithSkipAndStatus creates a new error skipping the number of function on the stack and GRPC status
 
 <a name="NewWithStatus"></a>
-### func [NewWithStatus](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L183>)
+### func [NewWithStatus](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L185>)
 
 ```go
 func NewWithStatus(msg string, status *grpcstatus.Status) ErrorExt
@@ -237,7 +237,7 @@ func NewWithStatus(msg string, status *grpcstatus.Status) ErrorExt
 NewWithStatus creates a new error with statck information and GRPC status
 
 <a name="Newf"></a>
-### func [Newf](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L268>)
+### func [Newf](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L271>)
 
 ```go
 func Newf(format string, args ...any) ErrorExt
@@ -275,7 +275,7 @@ user alice not found
 </details>
 
 <a name="Wrap"></a>
-### func [Wrap](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L198>)
+### func [Wrap](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L200>)
 
 ```go
 func Wrap(err error, msg string) ErrorExt
@@ -349,7 +349,7 @@ true
 </details>
 
 <a name="WrapWithSkip"></a>
-### func [WrapWithSkip](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L208>)
+### func [WrapWithSkip](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L210>)
 
 ```go
 func WrapWithSkip(err error, msg string, skip int) ErrorExt
@@ -358,7 +358,7 @@ func WrapWithSkip(err error, msg string, skip int) ErrorExt
 WrapWithSkip wraps an existing error and appends stack information if it does not exists skipping the number of function on the stack
 
 <a name="WrapWithSkipAndStatus"></a>
-### func [WrapWithSkipAndStatus](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L213>)
+### func [WrapWithSkipAndStatus](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L215>)
 
 ```go
 func WrapWithSkipAndStatus(err error, msg string, skip int, status *grpcstatus.Status) ErrorExt
@@ -367,7 +367,7 @@ func WrapWithSkipAndStatus(err error, msg string, skip int, status *grpcstatus.S
 WrapWithSkip wraps an existing error and appends stack information if it does not exists skipping the number of function on the stack along with GRPC status
 
 <a name="WrapWithStatus"></a>
-### func [WrapWithStatus](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L203>)
+### func [WrapWithStatus](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L205>)
 
 ```go
 func WrapWithStatus(err error, msg string, status *grpcstatus.Status) ErrorExt
@@ -412,7 +412,7 @@ gRPC code: NotFound
 </details>
 
 <a name="Wrapf"></a>
-### func [Wrapf](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L273>)
+### func [Wrapf](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L276>)
 
 ```go
 func Wrapf(err error, format string, args ...any) ErrorExt

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,43 @@
+package errors
+
+import (
+	"testing"
+)
+
+func BenchmarkNew(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = New("benchmark error")
+	}
+}
+
+func BenchmarkNewAndStackFrame(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		e := New("benchmark error")
+		_ = e.StackFrame()
+	}
+}
+
+func BenchmarkWrap(b *testing.B) {
+	base := New("base error")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = Wrap(base, "wrapped")
+	}
+}
+
+func BenchmarkNewDeepStack(b *testing.B) {
+	b.ReportAllocs()
+	var recurse func(depth int) ErrorExt
+	recurse = func(depth int) ErrorExt {
+		if depth == 0 {
+			return New("deep error")
+		}
+		return recurse(depth - 1)
+	}
+	for b.Loop() {
+		_ = recurse(32)
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -19,7 +19,7 @@ const SupportPackageIsVersion1 = true
 const defaultStackDepth = 16
 
 var (
-	basePath         = ""
+	atomicBasePath   atomic.Value // stores string
 	atomicStackDepth atomic.Int32
 )
 
@@ -128,7 +128,7 @@ func (c *customError) captureStack(skip int) {
 	pcs := make([]uintptr, depth)
 	n := runtime.Callers(skip+2, pcs)
 	c.stack = pcs[:n]
-	c.basePath = basePath
+	c.basePath, _ = atomicBasePath.Load().(string)
 }
 
 // resolveFrames converts program counters to structured stack frames.
@@ -285,6 +285,6 @@ func Wrapf(err error, format string, args ...any) ErrorExt {
 func SetBaseFilePath(path string) {
 	path = strings.TrimSpace(path)
 	if path != "" {
-		basePath = path
+		atomicBasePath.Store(path)
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
@@ -14,9 +16,11 @@ import (
 // Downstream packages reference this to enforce version compatibility.
 const SupportPackageIsVersion1 = true
 
+const defaultStackDepth = 16
+
 var (
-	basePath      = ""
-	maxStackDepth = 64
+	basePath         = ""
+	atomicStackDepth atomic.Int32
 )
 
 // StackFrame represents the stackframe for tracing exception
@@ -52,6 +56,7 @@ type customError struct {
 	Msg          string
 	stack        []uintptr
 	frame        []StackFrame
+	frameOnce    sync.Once
 	cause        error
 	wrapped      error // immediate parent for Unwrap() chain; may differ from cause
 	shouldNotify bool
@@ -69,32 +74,38 @@ func (c *customError) Notified(status bool) {
 }
 
 // Error returns the error message.
-func (c customError) Error() string {
+func (c *customError) Error() string {
 	return c.Msg
 }
 
 // Callers returns the program counters of the call stack when the error was created.
-func (c customError) Callers() []uintptr {
+func (c *customError) Callers() []uintptr {
 	return c.stack[:]
 }
 
 // StackTrace returns the program counters of the call stack (alias for Callers).
-func (c customError) StackTrace() []uintptr {
+func (c *customError) StackTrace() []uintptr {
 	return c.Callers()
 }
 
 // StackFrame returns the structured stack frames for the error.
-func (c customError) StackFrame() []StackFrame {
+// Frames are resolved lazily from program counters on first access.
+func (c *customError) StackFrame() []StackFrame {
+	c.frameOnce.Do(func() {
+		if len(c.stack) > 0 {
+			c.frame = resolveFrames(c.stack)
+		}
+	})
 	return c.frame
 }
 
 // Cause returns the root cause error that originated this error chain.
-func (c customError) Cause() error {
+func (c *customError) Cause() error {
 	return c.cause
 }
 
 // GRPCStatus returns the gRPC status for this error.
-func (c customError) GRPCStatus() *grpcstatus.Status {
+func (c *customError) GRPCStatus() *grpcstatus.Status {
 	if c.status != nil {
 		// use latest error message and keep other data (e.g. details)
 		newStatus := c.status.Proto()
@@ -106,43 +117,50 @@ func (c customError) GRPCStatus() *grpcstatus.Status {
 	return grpcstatus.New(codes.Internal, c.Error())
 }
 
-func (c *customError) generateStack(skip int) []StackFrame {
-	stack := []StackFrame{}
-	trace := []uintptr{}
-	for i := skip + 1; i < skip+1+maxStackDepth; i++ {
-		pc, file, line, ok := runtime.Caller(i)
-		if !ok {
-			break
-		}
-		_, funcName := packageFuncName(pc)
+// captureStack records program counters for the call stack.
+// Symbolization is deferred until StackFrame() is called.
+func (c *customError) captureStack(skip int) {
+	depth := int(atomicStackDepth.Load())
+	if depth == 0 {
+		depth = defaultStackDepth
+	}
+	pcs := make([]uintptr, depth)
+	n := runtime.Callers(skip+2, pcs)
+	c.stack = pcs[:n]
+}
+
+// resolveFrames converts program counters to structured stack frames.
+func resolveFrames(pcs []uintptr) []StackFrame {
+	frames := runtime.CallersFrames(pcs)
+	stack := make([]StackFrame, 0, len(pcs))
+	for {
+		frame, more := frames.Next()
+		file := frame.File
 		if basePath != "" {
-			file = strings.Replace(file, basePath, "", 1)
+			file = strings.TrimPrefix(file, basePath)
 		}
+		_, funcName := splitFuncName(frame.Function)
 		stack = append(stack, StackFrame{
 			File: file,
-			Line: line,
+			Line: frame.Line,
 			Func: funcName,
 		})
-		trace = append(trace, pc)
+		if !more {
+			break
+		}
 	}
-	c.frame = stack
-	c.stack = trace
 	return stack
 }
 
 // Unwrap returns the immediate parent error for use with errors.Is and errors.As.
-func (c customError) Unwrap() error {
+func (c *customError) Unwrap() error {
 	return c.wrapped
 }
 
-func packageFuncName(pc uintptr) (string, string) {
-	f := runtime.FuncForPC(pc)
-	if f == nil {
-		return "", ""
-	}
-
+// splitFuncName splits a fully qualified function name into package and function parts.
+func splitFuncName(qualifiedName string) (string, string) {
 	packageName := ""
-	funcName := f.Name()
+	funcName := qualifiedName
 
 	if ind := strings.LastIndex(funcName, "/"); ind > 0 {
 		packageName += funcName[:ind+1]
@@ -220,7 +238,6 @@ func WrapWithSkipAndStatus(err error, msg string, skip int, status *grpcstatus.S
 		}
 
 		c.stack = e.Callers()
-		c.frame = e.StackFrame()
 		if n, ok := e.(NotifyExt); ok {
 			c.shouldNotify = n.ShouldNotify()
 		}
@@ -234,16 +251,16 @@ func WrapWithSkipAndStatus(err error, msg string, skip int, status *grpcstatus.S
 		shouldNotify: true,
 		status:       status,
 	}
-	c.generateStack(skip + 1)
+	c.captureStack(skip + 1)
 	return c
 
 }
 
 // SetMaxStackDepth sets the maximum number of stack frames captured when creating errors.
-// Default is 64. Must be called during initialization.
+// Default is 16. Safe for concurrent use.
 func SetMaxStackDepth(n int) {
 	if n > 0 {
-		maxStackDepth = n
+		atomicStackDepth.Store(int32(n))
 	}
 }
 

--- a/errors.go
+++ b/errors.go
@@ -259,7 +259,7 @@ func WrapWithSkipAndStatus(err error, msg string, skip int, status *grpcstatus.S
 // SetMaxStackDepth sets the maximum number of stack frames captured when creating errors.
 // Default is 16. Safe for concurrent use.
 func SetMaxStackDepth(n int) {
-	if n > 0 {
+	if n > 0 && n <= 256 {
 		atomicStackDepth.Store(int32(n))
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -57,6 +57,7 @@ type customError struct {
 	stack        []uintptr
 	frame        []StackFrame
 	frameOnce    sync.Once
+	basePath     string // snapshot of basePath at capture time
 	cause        error
 	wrapped      error // immediate parent for Unwrap() chain; may differ from cause
 	shouldNotify bool
@@ -93,7 +94,7 @@ func (c *customError) StackTrace() []uintptr {
 func (c *customError) StackFrame() []StackFrame {
 	c.frameOnce.Do(func() {
 		if len(c.stack) > 0 {
-			c.frame = resolveFrames(c.stack)
+			c.frame = resolveFrames(c.stack, c.basePath)
 		}
 	})
 	return c.frame
@@ -127,17 +128,18 @@ func (c *customError) captureStack(skip int) {
 	pcs := make([]uintptr, depth)
 	n := runtime.Callers(skip+2, pcs)
 	c.stack = pcs[:n]
+	c.basePath = basePath
 }
 
 // resolveFrames converts program counters to structured stack frames.
-func resolveFrames(pcs []uintptr) []StackFrame {
+func resolveFrames(pcs []uintptr, base string) []StackFrame {
 	frames := runtime.CallersFrames(pcs)
 	stack := make([]StackFrame, 0, len(pcs))
 	for {
 		frame, more := frames.Next()
 		file := frame.File
-		if basePath != "" {
-			file = strings.TrimPrefix(file, basePath)
+		if base != "" {
+			file = strings.TrimPrefix(file, base)
 		}
 		_, funcName := splitFuncName(frame.Function)
 		stack = append(stack, StackFrame{
@@ -257,7 +259,8 @@ func WrapWithSkipAndStatus(err error, msg string, skip int, status *grpcstatus.S
 }
 
 // SetMaxStackDepth sets the maximum number of stack frames captured when creating errors.
-// Default is 16. Safe for concurrent use.
+// Accepts values in [1, 256]; out-of-range values are ignored. Default is 16.
+// Safe for concurrent use.
 func SetMaxStackDepth(n int) {
 	if n > 0 && n <= 256 {
 		atomicStackDepth.Store(int32(n))

--- a/errors.go
+++ b/errors.go
@@ -134,7 +134,8 @@ func (c *customError) captureStack(skip int) {
 // resolveFrames converts program counters to structured stack frames.
 func resolveFrames(pcs []uintptr, base string) []StackFrame {
 	frames := runtime.CallersFrames(pcs)
-	stack := make([]StackFrame, 0, len(pcs))
+	maxFrames := len(pcs)
+	stack := make([]StackFrame, 0, maxFrames)
 	for {
 		frame, more := frames.Next()
 		file := frame.File
@@ -147,7 +148,7 @@ func resolveFrames(pcs []uintptr, base string) []StackFrame {
 			Line: frame.Line,
 			Func: funcName,
 		})
-		if !more {
+		if !more || len(stack) >= maxFrames {
 			break
 		}
 	}
@@ -240,6 +241,9 @@ func WrapWithSkipAndStatus(err error, msg string, skip int, status *grpcstatus.S
 		}
 
 		c.stack = e.Callers()
+		if ce, ok := e.(*customError); ok {
+			c.basePath = ce.basePath
+		}
 		if n, ok := e.(NotifyExt); ok {
 			c.shouldNotify = n.ShouldNotify()
 		}

--- a/errors_test.go
+++ b/errors_test.go
@@ -106,8 +106,13 @@ func TestWrapf(t *testing.T) {
 
 func TestStackDepthCapped(t *testing.T) {
 	err := New("test")
+	// Assert on Callers (PCs) since StackFrame may expand due to inlining
+	if len(err.Callers()) > defaultStackDepth {
+		t.Errorf("callers depth %d exceeds max %d", len(err.Callers()), defaultStackDepth)
+	}
+	// StackFrame is also capped at len(pcs)
 	if len(err.StackFrame()) > defaultStackDepth {
-		t.Errorf("stack depth %d exceeds max %d", len(err.StackFrame()), defaultStackDepth)
+		t.Errorf("frame depth %d exceeds max %d", len(err.StackFrame()), defaultStackDepth)
 	}
 }
 
@@ -121,11 +126,11 @@ func TestStackDepthCappedDeep(t *testing.T) {
 	}
 
 	err := createDeepError(100)
-	if len(err.StackFrame()) > defaultStackDepth {
-		t.Errorf("stack depth %d exceeds max %d", len(err.StackFrame()), defaultStackDepth)
+	if len(err.Callers()) > defaultStackDepth {
+		t.Errorf("callers depth %d exceeds max %d", len(err.Callers()), defaultStackDepth)
 	}
-	if len(err.StackFrame()) == 0 {
-		t.Error("stack should not be empty")
+	if len(err.Callers()) == 0 {
+		t.Error("callers should not be empty")
 	}
 }
 
@@ -181,13 +186,14 @@ func TestStackFrameConsistency(t *testing.T) {
 		}
 	}
 
-	// Callers should remain unchanged
+	// Callers should be non-empty
 	pcs := err.Callers()
 	if len(pcs) == 0 {
 		t.Fatal("Callers() should not be empty")
 	}
-	if len(pcs) != len(frames1) {
-		t.Fatalf("Callers count %d != StackFrame count %d", len(pcs), len(frames1))
+	// Frames should not exceed PCs (inlining can expand, but resolveFrames caps)
+	if len(frames1) > len(pcs) {
+		t.Fatalf("StackFrame count %d exceeds Callers count %d", len(frames1), len(pcs))
 	}
 }
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -105,10 +105,9 @@ func TestWrapf(t *testing.T) {
 }
 
 func TestStackDepthCapped(t *testing.T) {
-	// With default max of 64, stack should never exceed that
 	err := New("test")
-	if len(err.StackFrame()) > 64 {
-		t.Errorf("stack depth %d exceeds max 64", len(err.StackFrame()))
+	if len(err.StackFrame()) > defaultStackDepth {
+		t.Errorf("stack depth %d exceeds max %d", len(err.StackFrame()), defaultStackDepth)
 	}
 }
 
@@ -121,13 +120,74 @@ func TestStackDepthCappedDeep(t *testing.T) {
 		return createDeepError(depth - 1)
 	}
 
-	// Create error from a stack deeper than 64
 	err := createDeepError(100)
-	if len(err.StackFrame()) > 64 {
-		t.Errorf("stack depth %d exceeds max 64", len(err.StackFrame()))
+	if len(err.StackFrame()) > defaultStackDepth {
+		t.Errorf("stack depth %d exceeds max %d", len(err.StackFrame()), defaultStackDepth)
 	}
 	if len(err.StackFrame()) == 0 {
 		t.Error("stack should not be empty")
+	}
+}
+
+func TestSetMaxStackDepth(t *testing.T) {
+	// Save and restore
+	prev := atomicStackDepth.Load()
+	defer atomicStackDepth.Store(prev)
+
+	SetMaxStackDepth(8)
+	if got := atomicStackDepth.Load(); got != 8 {
+		t.Fatalf("expected depth 8, got %d", got)
+	}
+
+	// Zero is ignored
+	SetMaxStackDepth(0)
+	if got := atomicStackDepth.Load(); got != 8 {
+		t.Fatalf("expected depth 8 (unchanged), got %d", got)
+	}
+
+	// Negative is ignored
+	SetMaxStackDepth(-1)
+	if got := atomicStackDepth.Load(); got != 8 {
+		t.Fatalf("expected depth 8 (unchanged), got %d", got)
+	}
+
+	// Over 256 is ignored
+	SetMaxStackDepth(1000)
+	if got := atomicStackDepth.Load(); got != 8 {
+		t.Fatalf("expected depth 8 (unchanged), got %d", got)
+	}
+
+	// 256 is accepted
+	SetMaxStackDepth(256)
+	if got := atomicStackDepth.Load(); got != 256 {
+		t.Fatalf("expected depth 256, got %d", got)
+	}
+}
+
+func TestStackFrameConsistency(t *testing.T) {
+	err := New("consistency test")
+
+	// First call resolves lazily
+	frames1 := err.StackFrame()
+	// Second call returns cached result
+	frames2 := err.StackFrame()
+
+	if len(frames1) != len(frames2) {
+		t.Fatalf("frame count changed: %d vs %d", len(frames1), len(frames2))
+	}
+	for i := range frames1 {
+		if frames1[i] != frames2[i] {
+			t.Fatalf("frame %d differs: %+v vs %+v", i, frames1[i], frames2[i])
+		}
+	}
+
+	// Callers should remain unchanged
+	pcs := err.Callers()
+	if len(pcs) == 0 {
+		t.Fatal("Callers() should not be empty")
+	}
+	if len(pcs) != len(frames1) {
+		t.Fatalf("Callers count %d != StackFrame count %d", len(pcs), len(frames1))
 	}
 }
 

--- a/notifier/README.md
+++ b/notifier/README.md
@@ -39,7 +39,7 @@ import "github.com/go-coldbrew/errors/notifier"
 
 
 <a name="Close"></a>
-## func [Close](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L483>)
+## func [Close](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L493>)
 
 ```go
 func Close()
@@ -57,7 +57,7 @@ func GetTraceHeaderName() string
 GetTraceHeaderName gets the header name for trace id default is x\-trace\-id
 
 <a name="GetTraceId"></a>
-## func [GetTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L543>)
+## func [GetTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L553>)
 
 ```go
 func GetTraceId(ctx context.Context) string
@@ -111,7 +111,7 @@ func NotifyAsync(err error, rawData ...interface{}) error
 NotifyAsync sends an error notification asynchronously with bounded concurrency. If the async notification pool is full, the notification is dropped to prevent goroutine explosion under sustained error bursts. Returns the original error for convenience.
 
 <a name="NotifyOnPanic"></a>
-## func [NotifyOnPanic](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L445>)
+## func [NotifyOnPanic](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L455>)
 
 ```go
 func NotifyOnPanic(rawData ...interface{})
@@ -120,7 +120,7 @@ func NotifyOnPanic(rawData ...interface{})
 NotifyOnPanic notifies error to airbrake, rollbar and sentry if they are inited and error is not ignored rawData: extra data to notify with error \(can be context.Context, Tags, or any other data\) when rawData is context.Context, it will used to get extra data from loggers.FromContext\(ctx\) and tags from metadata this function should be called in defer example: defer NotifyOnPanic\(ctx, "some data"\) example: defer NotifyOnPanic\(ctx, "some data", Tags\{"tag1": "value1"\}\)
 
 <a name="NotifyWithExclude"></a>
-## func [NotifyWithExclude](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L414>)
+## func [NotifyWithExclude](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L424>)
 
 ```go
 func NotifyWithExclude(err error, rawData ...interface{}) error
@@ -147,7 +147,7 @@ func NotifyWithLevelAndSkip(err error, skip int, level string, rawData ...interf
 NotifyWithLevelAndSkip notifies error to airbrake, rollbar and sentry if they are inited and error is not ignored err: error to notify skip: skip stack frames when notify error level: error level rawData: extra data to notify with error \(can be context.Context, Tags, or any other data\) when rawData is context.Context, it will used to get extra data from loggers.FromContext\(ctx\) and tags from metadata
 
 <a name="SetEnvironment"></a>
-## func [SetEnvironment](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L494>)
+## func [SetEnvironment](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L504>)
 
 ```go
 func SetEnvironment(env string)
@@ -156,7 +156,7 @@ func SetEnvironment(env string)
 SetEnvironment sets the environment. The environment is used to distinguish errors occurring in different
 
 <a name="SetHostname"></a>
-## func [SetHostname](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L579>)
+## func [SetHostname](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L589>)
 
 ```go
 func SetHostname(name string)
@@ -174,7 +174,7 @@ func SetMaxAsyncNotifications(n int)
 SetMaxAsyncNotifications sets the maximum number of concurrent async notification goroutines. When the limit is reached, new async notifications are dropped to prevent goroutine explosion under sustained error bursts. Default is 1000. Can only be called once; subsequent calls are no\-ops.
 
 <a name="SetRelease"></a>
-## func [SetRelease](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L507>)
+## func [SetRelease](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L517>)
 
 ```go
 func SetRelease(rel string)
@@ -183,7 +183,7 @@ func SetRelease(rel string)
 SetRelease sets the release tag. The release tag is used to group errors together by release.
 
 <a name="SetServerRoot"></a>
-## func [SetServerRoot](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L573>)
+## func [SetServerRoot](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L583>)
 
 ```go
 func SetServerRoot(path string)
@@ -201,7 +201,7 @@ func SetTraceHeaderName(name string)
 SetTraceHeaderName sets the header name for trace id default is x\-trace\-id
 
 <a name="SetTraceId"></a>
-## func [SetTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L514>)
+## func [SetTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L524>)
 
 ```go
 func SetTraceId(ctx context.Context) context.Context
@@ -210,7 +210,7 @@ func SetTraceId(ctx context.Context) context.Context
 SetTraceId updates the traceID based on context values if no trace id is found then it will create one and update the context You should use the context returned by this function instead of the one passed
 
 <a name="UpdateTraceId"></a>
-## func [UpdateTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L563>)
+## func [UpdateTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L573>)
 
 ```go
 func UpdateTraceId(ctx context.Context, traceID string) context.Context


### PR DESCRIPTION
## Summary

Replaces eager per-frame stack capture with batch PC capture and deferred symbolization, reducing error creation cost by 6.5x on the hot path.

### What changed
- **Batch PC capture**: single `runtime.Callers()` call replaces a loop of `runtime.Caller(i)` + `runtime.FuncForPC(pc)` per frame
- **Lazy symbolization**: `StackFrame()` resolves frames on first access via `sync.Once`, not at creation time
- **Default depth**: reduced from 64 to 16 frames (configurable via `SetMaxStackDepth`)
- **Thread-safe config**: `SetMaxStackDepth` uses `atomic.Int32`, safe for concurrent use
- **Consistent pointer receivers**: all `customError` methods use pointer receivers (required by `sync.Once`)

### Benchmark results (Apple M1 Pro)

| Benchmark | Before | After | Improvement |
|---|---|---|---|
| `errors.New` | 3500 ns / 1600 B / 19 allocs | 540 ns / 392 B / 6 allocs | **6.5x faster, 75% less memory** |
| `New` + `StackFrame()` | 3500 ns / 1600 B / 19 allocs | 1250 ns / 824 B / 9 allocs | **2.8x faster, 49% less memory** |
| `Wrap` (reuse stack) | 120 ns / 240 B / 4 allocs | 110 ns / 256 B / 4 allocs | ~same |
| `NewDeepStack` (32 frames) | 40500 ns / 17 KB / 125 allocs | 1060 ns / 392 B / 6 allocs | **38x faster, 98% less memory** |

### Compatibility
- `Callers() []uintptr` — unchanged, returns raw PCs as before
- `StackFrame() []StackFrame` — same output, now lazy. Sentry/Rollbar/Airbrake notifiers all work unchanged
- `SetMaxStackDepth(n)` — now thread-safe, default lowered to 16

## Test plan
- [x] `make test` passes with `-race` (both errors and notifier packages)
- [x] `make build` compiles cleanly
- [x] Benchmarks added (`bench_test.go`)
- [ ] Deploy to staging and verify stack traces in error notifications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added documented SupportPackageIsVersion1 constant.

* **Bug Fixes**
  * Stack-depth and base-path configuration made concurrency-safe; SetMaxStackDepth now ignores out-of-range inputs.

* **Changes**
  * Default max stack depth reduced to 16.
  * Stack-frame resolution is now lazy and cached to improve performance and reduce allocations.

* **Documentation**
  * README/API docs updated and index entry added.

* **Tests**
  * New benchmarks and tests for stack depth, frame consistency, and related behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->