### PR TITLE
feat: link ColdBrew trace ID to OTEL span as attribute

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-coldbrew/options v0.2.6
 	github.com/google/uuid v1.6.0
 	github.com/rollbar/rollbar-go v1.4.8
+	go.opentelemetry.io/otel v1.42.0
 	go.opentelemetry.io/otel/trace v1.42.0
 	google.golang.org/grpc v1.79.3
 )
@@ -236,7 +237,6 @@ require (
 	go-simpler.org/sloglint v0.11.1 // indirect
 	go.augendre.info/arangolint v0.4.0 // indirect
 	go.augendre.info/fatcontext v0.9.0 // indirect
-	go.opentelemetry.io/otel v1.42.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.8
 require (
 	github.com/airbrake/gobrake/v5 v5.6.2
 	github.com/getsentry/sentry-go v0.43.0
-	github.com/go-coldbrew/log v0.2.7
+	github.com/go-coldbrew/log v0.2.8
 	github.com/go-coldbrew/options v0.2.6
 	github.com/google/uuid v1.6.0
 	github.com/rollbar/rollbar-go v1.4.8
@@ -88,8 +88,6 @@ require (
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.8.0 // indirect
 	github.com/go-git/go-git/v5 v5.17.1 // indirect
-	github.com/go-kit/log v0.2.1 // indirect
-	github.com/go-logfmt/logfmt v0.6.1 // indirect
 	github.com/go-toolsmith/astcast v1.1.0 // indirect
 	github.com/go-toolsmith/astcopy v1.1.0 // indirect
 	github.com/go-toolsmith/astequal v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -221,8 +221,8 @@ github.com/ghostiam/protogetter v0.3.20 h1:oW7OPFit2FxZOpmMRPP9FffU4uUpfeE/rEdE1
 github.com/ghostiam/protogetter v0.3.20/go.mod h1:FjIu5Yfs6FT391m+Fjp3fbAYJ6rkL/J6ySpZBfnODuI=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
-github.com/go-coldbrew/log v0.2.7 h1:kRQeTYLPLcjjAWuCcGZpNn8twSY/NbsGpjIKbpXEnRA=
-github.com/go-coldbrew/log v0.2.7/go.mod h1:BB+2VecklLXTaDQdNNe2h3r5rSZL2DGvJBXAgrXq1dk=
+github.com/go-coldbrew/log v0.2.8 h1:aF+vw23zMyh5S9vhhofERiaPpSDyeJH1Tv1CYREn/a0=
+github.com/go-coldbrew/log v0.2.8/go.mod h1:RKvGzMZMt7FpQ9u36adkDigRxkOvRj1diwgAgRJZH4E=
 github.com/go-coldbrew/options v0.2.6 h1:Nr93v7PbO+EYLHhzA8biGumaTTSHLHqTYLg70n/foXE=
 github.com/go-coldbrew/options v0.2.6/go.mod h1:Os4pZwIgMHES079iOKXTlzcipWXbxw0OhsAN5D9m2mM=
 github.com/go-critic/go-critic v0.14.3 h1:5R1qH2iFeo4I/RJU8vTezdqs08Egi4u5p6vOESA0pog=

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -19,6 +19,7 @@ import (
 	"github.com/go-coldbrew/options"
 	"github.com/google/uuid"
 	rollbar "github.com/rollbar/rollbar-go"
+	otelattr "go.opentelemetry.io/otel/attribute"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/metadata"
 )
@@ -537,6 +538,7 @@ func SetTraceId(ctx context.Context) context.Context {
 		return ctx
 	}
 	var traceID string
+	// Check gRPC metadata first — client-supplied trace ID takes priority.
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
 		if id, ok := md["grpcmetadata-"+traceHeader]; ok {
 			traceID = strings.Join(id, ",")
@@ -544,16 +546,24 @@ func SetTraceId(ctx context.Context) context.Context {
 			traceID = strings.Join(id, ",")
 		}
 	}
-	if span := oteltrace.SpanFromContext(ctx); span.SpanContext().IsValid() && strings.TrimSpace(traceID) == "" {
-		traceID = span.SpanContext().TraceID().String()
+	// Fall back to OTEL span trace ID.
+	if strings.TrimSpace(traceID) == "" {
+		if span := oteltrace.SpanFromContext(ctx); span.SpanContext().IsValid() {
+			traceID = span.SpanContext().TraceID().String()
+		}
 	}
-	// if no trace id then create one
+	// Last resort: generate UUID.
 	if strings.TrimSpace(traceID) == "" {
 		u, err := uuid.NewRandom()
 		if err != nil {
 			u, _ = uuid.NewUUID()
 		}
 		traceID = u.String()
+	}
+	// Link the resolved trace ID to the OTEL span as an attribute
+	// so ColdBrew correlation ID and distributed trace are connected.
+	if span := oteltrace.SpanFromContext(ctx); span.SpanContext().IsValid() {
+		span.SetAttributes(otelattr.String("coldbrew.trace_id", traceID))
 	}
 	ctx = loggers.AddToLogContext(ctx, "trace", traceID)
 	return options.AddToOptions(ctx, tracerID, traceID)

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -534,7 +534,11 @@ func SetRelease(rel string) {
 // if no trace id is found then it will create one and update the context
 // You should use the context returned by this function instead of the one passed
 func SetTraceId(ctx context.Context) context.Context {
-	if GetTraceId(ctx) != "" {
+	if traceID := GetTraceId(ctx); traceID != "" {
+		// Trace ID already set — ensure it's linked to the OTEL span.
+		if span := oteltrace.SpanFromContext(ctx); span.SpanContext().IsValid() {
+			span.SetAttributes(otelattr.String("coldbrew.trace_id", traceID))
+		}
 		return ctx
 	}
 	var traceID string


### PR DESCRIPTION
## Summary
- Set `coldbrew.trace_id` attribute on the OTEL span after resolving the trace ID in `SetTraceId()`
- Connects the ColdBrew correlation ID to the distributed trace for easier cross-system debugging
- Also cleans up conditional ordering in SetTraceId for clarity

## Test plan
- [x] `go test -race ./...` passes
- [ ] Verify `coldbrew.trace_id` appears in OTEL span attributes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated logging library to latest version and removed indirect logging dependencies.
  * Promoted OpenTelemetry to direct dependency for tracing infrastructure.
  * Enhanced trace ID resolution with stricter priority ordering and improved fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->