### PR TITLE
security: validate client-supplied trace IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ const SupportPackageIsVersion1 = true
 ```
 
 <a name="SetBaseFilePath"></a>
-## func [SetBaseFilePath](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L281>)
+## func [SetBaseFilePath](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L285>)
 
 ```go
 func SetBaseFilePath(path string)
@@ -143,7 +143,7 @@ func SetBaseFilePath(path string)
 SetBaseFilePath sets the base file path for linking source code with reported stack information
 
 <a name="SetMaxStackDepth"></a>
-## func [SetMaxStackDepth](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L264>)
+## func [SetMaxStackDepth](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L268>)
 
 ```go
 func SetMaxStackDepth(n int)
@@ -172,7 +172,7 @@ type ErrorExt interface {
 ```
 
 <a name="New"></a>
-### func [New](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L180>)
+### func [New](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L181>)
 
 ```go
 func New(msg string) ErrorExt
@@ -210,7 +210,7 @@ something went wrong
 </details>
 
 <a name="NewWithSkip"></a>
-### func [NewWithSkip](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L190>)
+### func [NewWithSkip](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L191>)
 
 ```go
 func NewWithSkip(msg string, skip int) ErrorExt
@@ -219,7 +219,7 @@ func NewWithSkip(msg string, skip int) ErrorExt
 NewWithSkip creates a new error skipping the number of function on the stack
 
 <a name="NewWithSkipAndStatus"></a>
-### func [NewWithSkipAndStatus](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L195>)
+### func [NewWithSkipAndStatus](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L196>)
 
 ```go
 func NewWithSkipAndStatus(msg string, skip int, status *grpcstatus.Status) ErrorExt
@@ -228,7 +228,7 @@ func NewWithSkipAndStatus(msg string, skip int, status *grpcstatus.Status) Error
 NewWithSkipAndStatus creates a new error skipping the number of function on the stack and GRPC status
 
 <a name="NewWithStatus"></a>
-### func [NewWithStatus](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L185>)
+### func [NewWithStatus](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L186>)
 
 ```go
 func NewWithStatus(msg string, status *grpcstatus.Status) ErrorExt
@@ -237,7 +237,7 @@ func NewWithStatus(msg string, status *grpcstatus.Status) ErrorExt
 NewWithStatus creates a new error with statck information and GRPC status
 
 <a name="Newf"></a>
-### func [Newf](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L271>)
+### func [Newf](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L275>)
 
 ```go
 func Newf(format string, args ...any) ErrorExt
@@ -275,7 +275,7 @@ user alice not found
 </details>
 
 <a name="Wrap"></a>
-### func [Wrap](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L200>)
+### func [Wrap](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L201>)
 
 ```go
 func Wrap(err error, msg string) ErrorExt
@@ -349,7 +349,7 @@ true
 </details>
 
 <a name="WrapWithSkip"></a>
-### func [WrapWithSkip](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L210>)
+### func [WrapWithSkip](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L211>)
 
 ```go
 func WrapWithSkip(err error, msg string, skip int) ErrorExt
@@ -358,7 +358,7 @@ func WrapWithSkip(err error, msg string, skip int) ErrorExt
 WrapWithSkip wraps an existing error and appends stack information if it does not exists skipping the number of function on the stack
 
 <a name="WrapWithSkipAndStatus"></a>
-### func [WrapWithSkipAndStatus](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L215>)
+### func [WrapWithSkipAndStatus](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L216>)
 
 ```go
 func WrapWithSkipAndStatus(err error, msg string, skip int, status *grpcstatus.Status) ErrorExt
@@ -367,7 +367,7 @@ func WrapWithSkipAndStatus(err error, msg string, skip int, status *grpcstatus.S
 WrapWithSkip wraps an existing error and appends stack information if it does not exists skipping the number of function on the stack along with GRPC status
 
 <a name="WrapWithStatus"></a>
-### func [WrapWithStatus](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L205>)
+### func [WrapWithStatus](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L206>)
 
 ```go
 func WrapWithStatus(err error, msg string, status *grpcstatus.Status) ErrorExt
@@ -412,7 +412,7 @@ gRPC code: NotFound
 </details>
 
 <a name="Wrapf"></a>
-### func [Wrapf](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L276>)
+### func [Wrapf](<https://github.com/go-coldbrew/errors/blob/main/errors.go#L280>)
 
 ```go
 func Wrapf(err error, format string, args ...any) ErrorExt

--- a/notifier/README.md
+++ b/notifier/README.md
@@ -158,7 +158,7 @@ func SetEnvironment(env string)
 SetEnvironment sets the environment. The environment is used to distinguish errors occurring in different
 
 <a name="SetHostname"></a>
-## func [SetHostname](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L669>)
+## func [SetHostname](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L670>)
 
 ```go
 func SetHostname(name string)
@@ -185,7 +185,7 @@ func SetRelease(rel string)
 SetRelease sets the release tag. The release tag is used to group errors together by release.
 
 <a name="SetServerRoot"></a>
-## func [SetServerRoot](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L663>)
+## func [SetServerRoot](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L664>)
 
 ```go
 func SetServerRoot(path string)
@@ -203,13 +203,13 @@ func SetTraceHeaderName(name string)
 SetTraceHeaderName sets the header name for trace id default is x\-trace\-id
 
 <a name="SetTraceIDValidator"></a>
-## func [SetTraceIDValidator](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L618>)
+## func [SetTraceIDValidator](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L619>)
 
 ```go
 func SetTraceIDValidator(fn func(string) string)
 ```
 
-SetTraceIDValidator sets a custom trace ID validation function. The function receives a raw trace ID and must return the sanitized version. Return an empty string to trigger automatic trace ID generation. Set to nil to disable validation entirely \(not recommended\). Must be called during init — not safe for concurrent use.
+SetTraceIDValidator sets a custom trace ID validation function. The function receives a raw trace ID and must return the sanitized version. Returning an empty string triggers the standard trace ID resolution flow \(OTEL span trace ID → gRPC metadata → generate UUID\), not direct generation. Set to nil to disable validation entirely \(not recommended\). Must be called during init — not safe for concurrent use.
 
 <a name="SetTraceId"></a>
 ## func [SetTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L583>)
@@ -230,7 +230,7 @@ func SetTraceIdWithValue(ctx context.Context) (context.Context, string)
 SetTraceIdWithValue is like SetTraceId but also returns the resolved trace ID, avoiding a separate GetTraceId call. Callers must use the returned context, not the original ctx, so the stored trace ID is preserved in options and log context.
 
 <a name="UpdateTraceId"></a>
-## func [UpdateTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L650>)
+## func [UpdateTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L651>)
 
 ```go
 func UpdateTraceId(ctx context.Context, traceID string) context.Context

--- a/notifier/README.md
+++ b/notifier/README.md
@@ -34,12 +34,13 @@ import "github.com/go-coldbrew/errors/notifier"
 - [func SetServerRoot\(path string\)](<#SetServerRoot>)
 - [func SetTraceHeaderName\(name string\)](<#SetTraceHeaderName>)
 - [func SetTraceId\(ctx context.Context\) context.Context](<#SetTraceId>)
+- [func SetTraceIdWithValue\(ctx context.Context\) \(context.Context, string\)](<#SetTraceIdWithValue>)
 - [func UpdateTraceId\(ctx context.Context, traceID string\) context.Context](<#UpdateTraceId>)
 - [type Tags](<#Tags>)
 
 
 <a name="Close"></a>
-## func [Close](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L493>)
+## func [Close](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L505>)
 
 ```go
 func Close()
@@ -48,7 +49,7 @@ func Close()
 Close closes the airbrake notifier and flushes pending Sentry events. Sentry events are flushed with a 2 second timeout. You should call Close before app shutdown. Close doesn't call os.Exit.
 
 <a name="GetTraceHeaderName"></a>
-## func [GetTraceHeaderName](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L93>)
+## func [GetTraceHeaderName](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L105>)
 
 ```go
 func GetTraceHeaderName() string
@@ -57,7 +58,7 @@ func GetTraceHeaderName() string
 GetTraceHeaderName gets the header name for trace id default is x\-trace\-id
 
 <a name="GetTraceId"></a>
-## func [GetTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L553>)
+## func [GetTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L590>)
 
 ```go
 func GetTraceId(ctx context.Context) string
@@ -66,7 +67,7 @@ func GetTraceId(ctx context.Context) string
 GetTraceId fetches traceID from context if no trace id is found then it will return empty string
 
 <a name="InitAirbrake"></a>
-## func [InitAirbrake](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L113>)
+## func [InitAirbrake](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L125>)
 
 ```go
 func InitAirbrake(projectID int64, projectKey string)
@@ -75,7 +76,7 @@ func InitAirbrake(projectID int64, projectKey string)
 InitAirbrake inits airbrake configuration projectID: airbrake project id projectKey: airbrake project key
 
 <a name="InitRollbar"></a>
-## func [InitRollbar](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L124>)
+## func [InitRollbar](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L136>)
 
 ```go
 func InitRollbar(token, env string)
@@ -84,7 +85,7 @@ func InitRollbar(token, env string)
 InitRollbar inits rollbar configuration token: rollbar token env: rollbar environment
 
 <a name="InitSentry"></a>
-## func [InitSentry](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L156>)
+## func [InitSentry](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L168>)
 
 ```go
 func InitSentry(dsn string)
@@ -93,7 +94,7 @@ func InitSentry(dsn string)
 InitSentry inits sentry configuration dsn: sentry dsn
 
 <a name="Notify"></a>
-## func [Notify](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L254>)
+## func [Notify](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L266>)
 
 ```go
 func Notify(err error, rawData ...interface{}) error
@@ -102,7 +103,7 @@ func Notify(err error, rawData ...interface{}) error
 Notify notifies error to airbrake, rollbar and sentry if they are inited and error is not ignored err: error to notify rawData: extra data to notify with error \(can be context.Context, Tags, or any other data\) when rawData is context.Context, it will used to get extra data from loggers.FromContext\(ctx\) and tags from metadata
 
 <a name="NotifyAsync"></a>
-## func [NotifyAsync](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L66>)
+## func [NotifyAsync](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L78>)
 
 ```go
 func NotifyAsync(err error, rawData ...interface{}) error
@@ -111,7 +112,7 @@ func NotifyAsync(err error, rawData ...interface{}) error
 NotifyAsync sends an error notification asynchronously with bounded concurrency. If the async notification pool is full, the notification is dropped to prevent goroutine explosion under sustained error bursts. Returns the original error for convenience.
 
 <a name="NotifyOnPanic"></a>
-## func [NotifyOnPanic](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L455>)
+## func [NotifyOnPanic](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L467>)
 
 ```go
 func NotifyOnPanic(rawData ...interface{})
@@ -120,7 +121,7 @@ func NotifyOnPanic(rawData ...interface{})
 NotifyOnPanic notifies error to airbrake, rollbar and sentry if they are inited and error is not ignored rawData: extra data to notify with error \(can be context.Context, Tags, or any other data\) when rawData is context.Context, it will used to get extra data from loggers.FromContext\(ctx\) and tags from metadata this function should be called in defer example: defer NotifyOnPanic\(ctx, "some data"\) example: defer NotifyOnPanic\(ctx, "some data", Tags\{"tag1": "value1"\}\)
 
 <a name="NotifyWithExclude"></a>
-## func [NotifyWithExclude](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L424>)
+## func [NotifyWithExclude](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L436>)
 
 ```go
 func NotifyWithExclude(err error, rawData ...interface{}) error
@@ -129,7 +130,7 @@ func NotifyWithExclude(err error, rawData ...interface{}) error
 NotifyWithExclude notifies error to airbrake, rollbar and sentry if they are inited and error is not ignored err: error to notify rawData: extra data to notify with error \(can be context.Context, Tags, or any other data\) when rawData is context.Context, it will used to get extra data from loggers.FromContext\(ctx\) and tags from metadata
 
 <a name="NotifyWithLevel"></a>
-## func [NotifyWithLevel](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L263>)
+## func [NotifyWithLevel](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L275>)
 
 ```go
 func NotifyWithLevel(err error, level string, rawData ...interface{}) error
@@ -138,7 +139,7 @@ func NotifyWithLevel(err error, level string, rawData ...interface{}) error
 NotifyWithLevel notifies error to airbrake, rollbar and sentry if they are inited and error is not ignored err: error to notify level: error level rawData: extra data to notify with error \(can be context.Context, Tags, or any other data\) when rawData is context.Context, it will used to get extra data from loggers.FromContext\(ctx\) and tags from metadata
 
 <a name="NotifyWithLevelAndSkip"></a>
-## func [NotifyWithLevelAndSkip](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L314>)
+## func [NotifyWithLevelAndSkip](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L326>)
 
 ```go
 func NotifyWithLevelAndSkip(err error, skip int, level string, rawData ...interface{}) error
@@ -147,7 +148,7 @@ func NotifyWithLevelAndSkip(err error, skip int, level string, rawData ...interf
 NotifyWithLevelAndSkip notifies error to airbrake, rollbar and sentry if they are inited and error is not ignored err: error to notify skip: skip stack frames when notify error level: error level rawData: extra data to notify with error \(can be context.Context, Tags, or any other data\) when rawData is context.Context, it will used to get extra data from loggers.FromContext\(ctx\) and tags from metadata
 
 <a name="SetEnvironment"></a>
-## func [SetEnvironment](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L504>)
+## func [SetEnvironment](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L516>)
 
 ```go
 func SetEnvironment(env string)
@@ -156,7 +157,7 @@ func SetEnvironment(env string)
 SetEnvironment sets the environment. The environment is used to distinguish errors occurring in different
 
 <a name="SetHostname"></a>
-## func [SetHostname](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L589>)
+## func [SetHostname](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L654>)
 
 ```go
 func SetHostname(name string)
@@ -165,16 +166,16 @@ func SetHostname(name string)
 SetHostname sets the hostname of the server. The hostname is used to identify the server that logged an error.
 
 <a name="SetMaxAsyncNotifications"></a>
-## func [SetMaxAsyncNotifications](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L54>)
+## func [SetMaxAsyncNotifications](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L65>)
 
 ```go
 func SetMaxAsyncNotifications(n int)
 ```
 
-SetMaxAsyncNotifications sets the maximum number of concurrent async notification goroutines. When the limit is reached, new async notifications are dropped to prevent goroutine explosion under sustained error bursts. Default is 1000. Can only be called once; subsequent calls are no\-ops.
+SetMaxAsyncNotifications sets the maximum number of concurrent async notification goroutines. When the limit is reached, new async notifications are dropped to prevent goroutine explosion under sustained error bursts. Default is 20. The first successful call wins; subsequent calls are no\-ops. It is safe to call concurrently with NotifyAsync.
 
 <a name="SetRelease"></a>
-## func [SetRelease](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L517>)
+## func [SetRelease](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L529>)
 
 ```go
 func SetRelease(rel string)
@@ -183,7 +184,7 @@ func SetRelease(rel string)
 SetRelease sets the release tag. The release tag is used to group errors together by release.
 
 <a name="SetServerRoot"></a>
-## func [SetServerRoot](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L583>)
+## func [SetServerRoot](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L648>)
 
 ```go
 func SetServerRoot(path string)
@@ -192,7 +193,7 @@ func SetServerRoot(path string)
 SetServerRoot sets the root directory of the project. The root directory is used to trim prefixes from filenames in stack traces.
 
 <a name="SetTraceHeaderName"></a>
-## func [SetTraceHeaderName](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L87>)
+## func [SetTraceHeaderName](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L99>)
 
 ```go
 func SetTraceHeaderName(name string)
@@ -201,7 +202,7 @@ func SetTraceHeaderName(name string)
 SetTraceHeaderName sets the header name for trace id default is x\-trace\-id
 
 <a name="SetTraceId"></a>
-## func [SetTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L524>)
+## func [SetTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L583>)
 
 ```go
 func SetTraceId(ctx context.Context) context.Context
@@ -209,8 +210,17 @@ func SetTraceId(ctx context.Context) context.Context
 
 SetTraceId updates the traceID based on context values if no trace id is found then it will create one and update the context You should use the context returned by this function instead of the one passed
 
+<a name="SetTraceIdWithValue"></a>
+## func [SetTraceIdWithValue](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L537>)
+
+```go
+func SetTraceIdWithValue(ctx context.Context) (context.Context, string)
+```
+
+SetTraceIdWithValue is like SetTraceId but also returns the resolved trace ID, avoiding a separate GetTraceId call. Callers must use the returned context, not the original ctx, so the stored trace ID is preserved in options and log context.
+
 <a name="UpdateTraceId"></a>
-## func [UpdateTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L573>)
+## func [UpdateTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L637>)
 
 ```go
 func UpdateTraceId(ctx context.Context, traceID string) context.Context
@@ -219,7 +229,7 @@ func UpdateTraceId(ctx context.Context, traceID string) context.Context
 UpdateTraceId force updates the traced id to provided id if no trace id is found then it will create one and update the context You should use the context returned by this function instead of the one passed
 
 <a name="Tags"></a>
-## type [Tags](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L102>)
+## type [Tags](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L114>)
 
 
 

--- a/notifier/README.md
+++ b/notifier/README.md
@@ -209,7 +209,7 @@ SetTraceHeaderName sets the header name for trace id default is x\-trace\-id
 func SetTraceIDValidator(fn func(string) string)
 ```
 
-SetTraceIDValidator sets a custom trace ID validation function. The function receives a raw trace ID and must return the sanitized version. Returning an empty string triggers the standard trace ID resolution flow \(OTEL span trace ID → gRPC metadata → generate UUID\), not direct generation. Set to nil to disable validation entirely \(not recommended\). Must be called during init — not safe for concurrent use.
+SetTraceIDValidator sets a custom trace ID validation function. The function receives a raw trace ID and must return the sanitized version. Returning an empty string triggers the standard trace ID resolution flow \(existing ctx → gRPC metadata → OTEL span trace ID → generate UUID\), not direct generation. Set to nil to disable validation entirely \(not recommended\). Must be called during init — not safe for concurrent use.
 
 <a name="SetTraceId"></a>
 ## func [SetTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L583>)

--- a/notifier/README.md
+++ b/notifier/README.md
@@ -41,7 +41,7 @@ import "github.com/go-coldbrew/errors/notifier"
 
 
 <a name="Close"></a>
-## func [Close](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L505>)
+## func [Close](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L503>)
 
 ```go
 func Close()
@@ -50,7 +50,7 @@ func Close()
 Close closes the airbrake notifier and flushes pending Sentry events. Sentry events are flushed with a 2 second timeout. You should call Close before app shutdown. Close doesn't call os.Exit.
 
 <a name="GetTraceHeaderName"></a>
-## func [GetTraceHeaderName](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L105>)
+## func [GetTraceHeaderName](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L104>)
 
 ```go
 func GetTraceHeaderName() string
@@ -59,7 +59,7 @@ func GetTraceHeaderName() string
 GetTraceHeaderName gets the header name for trace id default is x\-trace\-id
 
 <a name="GetTraceId"></a>
-## func [GetTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L592>)
+## func [GetTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L590>)
 
 ```go
 func GetTraceId(ctx context.Context) string
@@ -68,7 +68,7 @@ func GetTraceId(ctx context.Context) string
 GetTraceId fetches traceID from context if no trace id is found then it will return empty string
 
 <a name="InitAirbrake"></a>
-## func [InitAirbrake](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L125>)
+## func [InitAirbrake](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L124>)
 
 ```go
 func InitAirbrake(projectID int64, projectKey string)
@@ -77,7 +77,7 @@ func InitAirbrake(projectID int64, projectKey string)
 InitAirbrake inits airbrake configuration projectID: airbrake project id projectKey: airbrake project key
 
 <a name="InitRollbar"></a>
-## func [InitRollbar](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L136>)
+## func [InitRollbar](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L135>)
 
 ```go
 func InitRollbar(token, env string)
@@ -86,7 +86,7 @@ func InitRollbar(token, env string)
 InitRollbar inits rollbar configuration token: rollbar token env: rollbar environment
 
 <a name="InitSentry"></a>
-## func [InitSentry](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L168>)
+## func [InitSentry](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L167>)
 
 ```go
 func InitSentry(dsn string)
@@ -95,7 +95,7 @@ func InitSentry(dsn string)
 InitSentry inits sentry configuration dsn: sentry dsn
 
 <a name="Notify"></a>
-## func [Notify](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L266>)
+## func [Notify](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L265>)
 
 ```go
 func Notify(err error, rawData ...interface{}) error
@@ -104,7 +104,7 @@ func Notify(err error, rawData ...interface{}) error
 Notify notifies error to airbrake, rollbar and sentry if they are inited and error is not ignored err: error to notify rawData: extra data to notify with error \(can be context.Context, Tags, or any other data\) when rawData is context.Context, it will used to get extra data from loggers.FromContext\(ctx\) and tags from metadata
 
 <a name="NotifyAsync"></a>
-## func [NotifyAsync](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L78>)
+## func [NotifyAsync](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L77>)
 
 ```go
 func NotifyAsync(err error, rawData ...interface{}) error
@@ -113,7 +113,7 @@ func NotifyAsync(err error, rawData ...interface{}) error
 NotifyAsync sends an error notification asynchronously with bounded concurrency. If the async notification pool is full, the notification is dropped to prevent goroutine explosion under sustained error bursts. Returns the original error for convenience.
 
 <a name="NotifyOnPanic"></a>
-## func [NotifyOnPanic](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L467>)
+## func [NotifyOnPanic](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L465>)
 
 ```go
 func NotifyOnPanic(rawData ...interface{})
@@ -122,7 +122,7 @@ func NotifyOnPanic(rawData ...interface{})
 NotifyOnPanic notifies error to airbrake, rollbar and sentry if they are inited and error is not ignored rawData: extra data to notify with error \(can be context.Context, Tags, or any other data\) when rawData is context.Context, it will used to get extra data from loggers.FromContext\(ctx\) and tags from metadata this function should be called in defer example: defer NotifyOnPanic\(ctx, "some data"\) example: defer NotifyOnPanic\(ctx, "some data", Tags\{"tag1": "value1"\}\)
 
 <a name="NotifyWithExclude"></a>
-## func [NotifyWithExclude](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L436>)
+## func [NotifyWithExclude](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L434>)
 
 ```go
 func NotifyWithExclude(err error, rawData ...interface{}) error
@@ -131,7 +131,7 @@ func NotifyWithExclude(err error, rawData ...interface{}) error
 NotifyWithExclude notifies error to airbrake, rollbar and sentry if they are inited and error is not ignored err: error to notify rawData: extra data to notify with error \(can be context.Context, Tags, or any other data\) when rawData is context.Context, it will used to get extra data from loggers.FromContext\(ctx\) and tags from metadata
 
 <a name="NotifyWithLevel"></a>
-## func [NotifyWithLevel](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L275>)
+## func [NotifyWithLevel](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L274>)
 
 ```go
 func NotifyWithLevel(err error, level string, rawData ...interface{}) error
@@ -140,7 +140,7 @@ func NotifyWithLevel(err error, level string, rawData ...interface{}) error
 NotifyWithLevel notifies error to airbrake, rollbar and sentry if they are inited and error is not ignored err: error to notify level: error level rawData: extra data to notify with error \(can be context.Context, Tags, or any other data\) when rawData is context.Context, it will used to get extra data from loggers.FromContext\(ctx\) and tags from metadata
 
 <a name="NotifyWithLevelAndSkip"></a>
-## func [NotifyWithLevelAndSkip](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L326>)
+## func [NotifyWithLevelAndSkip](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L325>)
 
 ```go
 func NotifyWithLevelAndSkip(err error, skip int, level string, rawData ...interface{}) error
@@ -149,7 +149,7 @@ func NotifyWithLevelAndSkip(err error, skip int, level string, rawData ...interf
 NotifyWithLevelAndSkip notifies error to airbrake, rollbar and sentry if they are inited and error is not ignored err: error to notify skip: skip stack frames when notify error level: error level rawData: extra data to notify with error \(can be context.Context, Tags, or any other data\) when rawData is context.Context, it will used to get extra data from loggers.FromContext\(ctx\) and tags from metadata
 
 <a name="SetEnvironment"></a>
-## func [SetEnvironment](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L516>)
+## func [SetEnvironment](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L514>)
 
 ```go
 func SetEnvironment(env string)
@@ -158,7 +158,7 @@ func SetEnvironment(env string)
 SetEnvironment sets the environment. The environment is used to distinguish errors occurring in different
 
 <a name="SetHostname"></a>
-## func [SetHostname](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L671>)
+## func [SetHostname](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L669>)
 
 ```go
 func SetHostname(name string)
@@ -167,7 +167,7 @@ func SetHostname(name string)
 SetHostname sets the hostname of the server. The hostname is used to identify the server that logged an error.
 
 <a name="SetMaxAsyncNotifications"></a>
-## func [SetMaxAsyncNotifications](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L65>)
+## func [SetMaxAsyncNotifications](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L64>)
 
 ```go
 func SetMaxAsyncNotifications(n int)
@@ -176,7 +176,7 @@ func SetMaxAsyncNotifications(n int)
 SetMaxAsyncNotifications sets the maximum number of concurrent async notification goroutines. When the limit is reached, new async notifications are dropped to prevent goroutine explosion under sustained error bursts. Default is 20. The first successful call wins; subsequent calls are no\-ops. It is safe to call concurrently with NotifyAsync.
 
 <a name="SetRelease"></a>
-## func [SetRelease](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L529>)
+## func [SetRelease](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L527>)
 
 ```go
 func SetRelease(rel string)
@@ -185,7 +185,7 @@ func SetRelease(rel string)
 SetRelease sets the release tag. The release tag is used to group errors together by release.
 
 <a name="SetServerRoot"></a>
-## func [SetServerRoot](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L665>)
+## func [SetServerRoot](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L663>)
 
 ```go
 func SetServerRoot(path string)
@@ -194,7 +194,7 @@ func SetServerRoot(path string)
 SetServerRoot sets the root directory of the project. The root directory is used to trim prefixes from filenames in stack traces.
 
 <a name="SetTraceHeaderName"></a>
-## func [SetTraceHeaderName](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L99>)
+## func [SetTraceHeaderName](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L98>)
 
 ```go
 func SetTraceHeaderName(name string)
@@ -203,7 +203,7 @@ func SetTraceHeaderName(name string)
 SetTraceHeaderName sets the header name for trace id default is x\-trace\-id
 
 <a name="SetTraceIDValidator"></a>
-## func [SetTraceIDValidator](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L620>)
+## func [SetTraceIDValidator](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L618>)
 
 ```go
 func SetTraceIDValidator(fn func(string) string)
@@ -212,7 +212,7 @@ func SetTraceIDValidator(fn func(string) string)
 SetTraceIDValidator sets a custom trace ID validation function. The function receives a raw trace ID and must return the sanitized version. Return an empty string to trigger automatic trace ID generation. Set to nil to disable validation entirely \(not recommended\). Must be called during init — not safe for concurrent use.
 
 <a name="SetTraceId"></a>
-## func [SetTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L585>)
+## func [SetTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L583>)
 
 ```go
 func SetTraceId(ctx context.Context) context.Context
@@ -221,7 +221,7 @@ func SetTraceId(ctx context.Context) context.Context
 SetTraceId updates the traceID based on context values if no trace id is found then it will create one and update the context You should use the context returned by this function instead of the one passed
 
 <a name="SetTraceIdWithValue"></a>
-## func [SetTraceIdWithValue](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L537>)
+## func [SetTraceIdWithValue](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L535>)
 
 ```go
 func SetTraceIdWithValue(ctx context.Context) (context.Context, string)
@@ -230,7 +230,7 @@ func SetTraceIdWithValue(ctx context.Context) (context.Context, string)
 SetTraceIdWithValue is like SetTraceId but also returns the resolved trace ID, avoiding a separate GetTraceId call. Callers must use the returned context, not the original ctx, so the stored trace ID is preserved in options and log context.
 
 <a name="UpdateTraceId"></a>
-## func [UpdateTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L652>)
+## func [UpdateTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L650>)
 
 ```go
 func UpdateTraceId(ctx context.Context, traceID string) context.Context
@@ -239,7 +239,7 @@ func UpdateTraceId(ctx context.Context, traceID string) context.Context
 UpdateTraceId force updates the traced id to provided id if no trace id is found then it will create one and update the context You should use the context returned by this function instead of the one passed
 
 <a name="Tags"></a>
-## type [Tags](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L114>)
+## type [Tags](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L113>)
 
 
 

--- a/notifier/README.md
+++ b/notifier/README.md
@@ -33,6 +33,7 @@ import "github.com/go-coldbrew/errors/notifier"
 - [func SetRelease\(rel string\)](<#SetRelease>)
 - [func SetServerRoot\(path string\)](<#SetServerRoot>)
 - [func SetTraceHeaderName\(name string\)](<#SetTraceHeaderName>)
+- [func SetTraceIDValidator\(fn func\(string\) string\)](<#SetTraceIDValidator>)
 - [func SetTraceId\(ctx context.Context\) context.Context](<#SetTraceId>)
 - [func SetTraceIdWithValue\(ctx context.Context\) \(context.Context, string\)](<#SetTraceIdWithValue>)
 - [func UpdateTraceId\(ctx context.Context, traceID string\) context.Context](<#UpdateTraceId>)
@@ -58,7 +59,7 @@ func GetTraceHeaderName() string
 GetTraceHeaderName gets the header name for trace id default is x\-trace\-id
 
 <a name="GetTraceId"></a>
-## func [GetTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L590>)
+## func [GetTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L592>)
 
 ```go
 func GetTraceId(ctx context.Context) string
@@ -157,7 +158,7 @@ func SetEnvironment(env string)
 SetEnvironment sets the environment. The environment is used to distinguish errors occurring in different
 
 <a name="SetHostname"></a>
-## func [SetHostname](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L654>)
+## func [SetHostname](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L671>)
 
 ```go
 func SetHostname(name string)
@@ -184,7 +185,7 @@ func SetRelease(rel string)
 SetRelease sets the release tag. The release tag is used to group errors together by release.
 
 <a name="SetServerRoot"></a>
-## func [SetServerRoot](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L648>)
+## func [SetServerRoot](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L665>)
 
 ```go
 func SetServerRoot(path string)
@@ -201,8 +202,17 @@ func SetTraceHeaderName(name string)
 
 SetTraceHeaderName sets the header name for trace id default is x\-trace\-id
 
+<a name="SetTraceIDValidator"></a>
+## func [SetTraceIDValidator](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L620>)
+
+```go
+func SetTraceIDValidator(fn func(string) string)
+```
+
+SetTraceIDValidator sets a custom trace ID validation function. The function receives a raw trace ID and must return the sanitized version. Return an empty string to trigger automatic trace ID generation. Set to nil to disable validation entirely \(not recommended\). Must be called during init — not safe for concurrent use.
+
 <a name="SetTraceId"></a>
-## func [SetTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L583>)
+## func [SetTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L585>)
 
 ```go
 func SetTraceId(ctx context.Context) context.Context
@@ -220,7 +230,7 @@ func SetTraceIdWithValue(ctx context.Context) (context.Context, string)
 SetTraceIdWithValue is like SetTraceId but also returns the resolved trace ID, avoiding a separate GetTraceId call. Callers must use the returned context, not the original ctx, so the stored trace ID is preserved in options and log context.
 
 <a name="UpdateTraceId"></a>
-## func [UpdateTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L637>)
+## func [UpdateTraceId](<https://github.com/go-coldbrew/errors/blob/main/notifier/notifier.go#L652>)
 
 ```go
 func UpdateTraceId(ctx context.Context, traceID string) context.Context

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -613,7 +613,7 @@ var traceIDValidator = validateTraceID
 // SetTraceIDValidator sets a custom trace ID validation function.
 // The function receives a raw trace ID and must return the sanitized version.
 // Returning an empty string triggers the standard trace ID resolution flow
-// (OTEL span trace ID → gRPC metadata → generate UUID), not direct generation.
+// (existing ctx → gRPC metadata → OTEL span trace ID → generate UUID), not direct generation.
 // Set to nil to disable validation entirely (not recommended).
 // Must be called during init — not safe for concurrent use.
 func SetTraceIDValidator(fn func(string) string) {

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -554,6 +554,8 @@ func SetTraceIdWithValue(ctx context.Context) (context.Context, string) {
 			traceID = strings.Join(id, ",")
 		}
 	}
+	// Sanitize client-supplied trace ID to prevent log injection and DoS.
+	traceID = validateTraceID(traceID)
 	// Fall back to OTEL span trace ID.
 	if strings.TrimSpace(traceID) == "" && hasSpan {
 		traceID = span.SpanContext().TraceID().String()
@@ -604,10 +606,36 @@ func GetTraceId(ctx context.Context) string {
 	return ""
 }
 
+// validateTraceID sanitizes a trace ID to prevent log injection and
+// ensure it is safe to propagate through logs, error reports, and
+// OTEL span attributes. Empty strings pass through unchanged.
+// Rules:
+//   - Maximum 128 characters (truncated if longer)
+//   - Only printable ASCII (0x20-0x7E) retained
+//   - Non-printable, control characters, and non-ASCII bytes are stripped
+func validateTraceID(id string) string {
+	if id == "" {
+		return ""
+	}
+	if len(id) > 128 {
+		id = id[:128]
+	}
+	var b strings.Builder
+	b.Grow(len(id))
+	for i := 0; i < len(id); i++ {
+		c := id[i]
+		if c >= 0x20 && c <= 0x7E {
+			b.WriteByte(c)
+		}
+	}
+	return b.String()
+}
+
 // UpdateTraceId force updates the traced id to provided id
 // if no trace id is found then it will create one and update the context
 // You should use the context returned by this function instead of the one passed
 func UpdateTraceId(ctx context.Context, traceID string) context.Context {
+	traceID = validateTraceID(traceID)
 	if traceID == "" {
 		return SetTraceId(ctx)
 	}

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -28,15 +28,14 @@ import (
 var _ = log.SupportPackageIsVersion1
 
 var (
-	airbrake           *gobrake.Notifier
-	rollbarInited      bool
-	sentryInited       bool
-	sentryEnvironment  string
-	sentryRelease      string
-	serverRoot         string
-	hostname           string
-	traceHeader        string = "x-trace-id"
-
+	airbrake          *gobrake.Notifier
+	rollbarInited     bool
+	sentryInited      bool
+	sentryEnvironment string
+	sentryRelease     string
+	serverRoot        string
+	hostname          string
+	traceHeader       string = "x-trace-id"
 )
 
 // asyncSem is a semaphore that bounds the number of concurrent async
@@ -335,7 +334,6 @@ func NotifyWithLevelAndSkip(err error, skip int, level string, rawData ...interf
 		n.Notified(true)
 	}
 	return doNotify(err, skip, level, rawData...)
-
 }
 
 func doNotify(err error, skip int, level string, rawData ...interface{}) error {
@@ -653,7 +651,7 @@ func UpdateTraceId(ctx context.Context, traceID string) context.Context {
 	if traceIDValidator != nil {
 		traceID = traceIDValidator(traceID)
 	}
-	if traceID == "" {
+	if strings.TrimSpace(traceID) == "" {
 		return SetTraceId(ctx)
 	}
 	ctx = loggers.AddToLogContext(ctx, "trace", traceID)

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -612,7 +612,8 @@ var traceIDValidator = validateTraceID
 
 // SetTraceIDValidator sets a custom trace ID validation function.
 // The function receives a raw trace ID and must return the sanitized version.
-// Return an empty string to trigger automatic trace ID generation.
+// Returning an empty string triggers the standard trace ID resolution flow
+// (OTEL span trace ID → gRPC metadata → generate UUID), not direct generation.
 // Set to nil to disable validation entirely (not recommended).
 // Must be called during init — not safe for concurrent use.
 func SetTraceIDValidator(fn func(string) string) {

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -555,7 +555,9 @@ func SetTraceIdWithValue(ctx context.Context) (context.Context, string) {
 		}
 	}
 	// Sanitize client-supplied trace ID to prevent log injection and DoS.
-	traceID = validateTraceID(traceID)
+	if traceIDValidator != nil {
+		traceID = traceIDValidator(traceID)
+	}
 	// Fall back to OTEL span trace ID.
 	if strings.TrimSpace(traceID) == "" && hasSpan {
 		traceID = span.SpanContext().TraceID().String()
@@ -606,6 +608,19 @@ func GetTraceId(ctx context.Context) string {
 	return ""
 }
 
+// traceIDValidator is the active trace ID validation function.
+// Defaults to validateTraceID. Set to nil to disable validation.
+var traceIDValidator = validateTraceID
+
+// SetTraceIDValidator sets a custom trace ID validation function.
+// The function receives a raw trace ID and must return the sanitized version.
+// Return an empty string to trigger automatic trace ID generation.
+// Set to nil to disable validation entirely (not recommended).
+// Must be called during init — not safe for concurrent use.
+func SetTraceIDValidator(fn func(string) string) {
+	traceIDValidator = fn
+}
+
 // validateTraceID sanitizes a trace ID to prevent log injection and
 // ensure it is safe to propagate through logs, error reports, and
 // OTEL span attributes. Empty strings pass through unchanged.
@@ -635,7 +650,9 @@ func validateTraceID(id string) string {
 // if no trace id is found then it will create one and update the context
 // You should use the context returned by this function instead of the one passed
 func UpdateTraceId(ctx context.Context, traceID string) context.Context {
-	traceID = validateTraceID(traceID)
+	if traceIDValidator != nil {
+		traceID = traceIDValidator(traceID)
+	}
 	if traceID == "" {
 		return SetTraceId(ctx)
 	}

--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -298,3 +298,36 @@ func TestUpdateTraceId_AllInvalidFallsBackToGenerated(t *testing.T) {
 		t.Error("expected a generated trace ID when all chars are invalid")
 	}
 }
+
+func TestSetTraceIDValidator_Custom(t *testing.T) {
+	old := traceIDValidator
+	t.Cleanup(func() { traceIDValidator = old })
+
+	SetTraceIDValidator(func(id string) string {
+		return "custom-" + id
+	})
+
+	md := metadata.Pairs(traceHeader, "abc")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	ctx = SetTraceId(ctx)
+	got := GetTraceId(ctx)
+	if got != "custom-abc" {
+		t.Errorf("expected custom validator applied, got %q", got)
+	}
+}
+
+func TestSetTraceIDValidator_Nil(t *testing.T) {
+	old := traceIDValidator
+	t.Cleanup(func() { traceIDValidator = old })
+
+	SetTraceIDValidator(nil)
+
+	// With nil validator, raw trace ID passes through unmodified
+	md := metadata.Pairs(traceHeader, "raw\x00id")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	ctx = SetTraceId(ctx)
+	got := GetTraceId(ctx)
+	if got != "raw\x00id" {
+		t.Errorf("expected raw trace ID with nil validator, got %q", got)
+	}
+}

--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -2,6 +2,7 @@ package notifier
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 
@@ -229,5 +230,71 @@ func TestSetTraceIdWithValue_SetsOTELAttribute(t *testing.T) {
 	}
 	if !found {
 		t.Error("coldbrew.trace_id attribute not found on span")
+	}
+}
+
+func TestValidateTraceID(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty stays empty", "", ""},
+		{"normal ASCII passes through", "abc-123-def", "abc-123-def"},
+		{"UUID passes through", "550e8400-e29b-41d4-a716-446655440000", "550e8400-e29b-41d4-a716-446655440000"},
+		{"truncated at 128 chars", strings.Repeat("a", 200), strings.Repeat("a", 128)},
+		{"newlines stripped", "abc\ndef\rghi", "abcdefghi"},
+		{"null bytes stripped", "abc\x00def", "abcdef"},
+		{"control chars stripped", "abc\x01\x02\x03def", "abcdef"},
+		{"tab stripped", "abc\tdef", "abcdef"},
+		{"spaces preserved", "abc def", "abc def"},
+		{"printable special chars preserved", "abc!@#$%^&*()def", "abc!@#$%^&*()def"},
+		{"only non-printable returns empty", "\x00\x01\x02", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := validateTraceID(tc.input)
+			if got != tc.want {
+				t.Errorf("validateTraceID(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSetTraceId_ValidatesMetadataTraceID(t *testing.T) {
+	md := metadata.Pairs(traceHeader, "valid-id-123\x00\nnewline")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	ctx = SetTraceId(ctx)
+	got := GetTraceId(ctx)
+	if got != "valid-id-123newline" {
+		t.Errorf("expected sanitized trace ID %q, got %q", "valid-id-123newline", got)
+	}
+}
+
+func TestSetTraceId_TruncatesLongMetadataTraceID(t *testing.T) {
+	longID := strings.Repeat("x", 200)
+	md := metadata.Pairs(traceHeader, longID)
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	ctx = SetTraceId(ctx)
+	got := GetTraceId(ctx)
+	if len(got) != 128 {
+		t.Errorf("expected truncated to 128 chars, got %d", len(got))
+	}
+}
+
+func TestUpdateTraceId_ValidatesInput(t *testing.T) {
+	ctx := options.AddToOptions(context.Background(), tracerID, "")
+	ctx = UpdateTraceId(ctx, "good-id\x00\nbad")
+	got := GetTraceId(ctx)
+	if got != "good-idbad" {
+		t.Errorf("expected sanitized trace ID %q, got %q", "good-idbad", got)
+	}
+}
+
+func TestUpdateTraceId_AllInvalidFallsBackToGenerated(t *testing.T) {
+	ctx := UpdateTraceId(context.Background(), "\x00\x01\x02")
+	got := GetTraceId(ctx)
+	if got == "" {
+		t.Error("expected a generated trace ID when all chars are invalid")
 	}
 }

--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -247,6 +247,7 @@ func TestValidateTraceID(t *testing.T) {
 		{"null bytes stripped", "abc\x00def", "abcdef"},
 		{"control chars stripped", "abc\x01\x02\x03def", "abcdef"},
 		{"tab stripped", "abc\tdef", "abcdef"},
+		{"non-ASCII UTF-8 stripped", "abc\xc3\xa9\xe4\xb8\xad\xf0\x9f\x99\x82def", "abcdef"},
 		{"spaces preserved", "abc def", "abc def"},
 		{"printable special chars preserved", "abc!@#$%^&*()def", "abc!@#$%^&*()def"},
 		{"only non-printable returns empty", "\x00\x01\x02", ""},


### PR DESCRIPTION
## Summary
- Add `validateTraceID` helper: max 128 chars, printable ASCII only (0x20-0x7E), strips control/unicode bytes
- Called in `SetTraceIdWithValue` (after gRPC metadata extraction) and `UpdateTraceId` (before storing)
- If all characters are invalid, falls back to generating a new UUID
- Protects structured logs, Sentry/Rollbar, and OTEL span attributes from log injection and DoS

## Test plan
- [x] `TestValidateTraceID` — table-driven: normal, truncation, stripping, edge cases
- [x] `TestSetTraceId_ValidatesMetadataTraceID` — dirty metadata sanitized
- [x] `TestSetTraceId_TruncatesLongMetadataTraceID` — 200 chars → 128
- [x] `TestUpdateTraceId_ValidatesInput` — dirty input sanitized
- [x] `TestUpdateTraceId_AllInvalidFallsBackToGenerated` — generates new UUID
- [x] `make test`, `make lint`, `make doc` all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to obtain the updated context along with the resolved trace ID.
  * Added a configurable trace-ID validator hook so callers can supply custom validation or disable it.

* **Improvements**
  * Trace IDs are automatically sanitized (printable ASCII only, truncated to 128 chars).
  * Reduced default async-notification limit from 1000 to 20 and clarified concurrency semantics.

* **Documentation**
  * Updated README links and API docs to reflect these changes.

* **Tests**
  * Added unit tests covering trace-ID sanitization and validator customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->