### PR TITLE
perf: fast-path in validateTraceID for clean trace IDs

### DIFF
--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -634,6 +634,19 @@ func validateTraceID(id string) string {
 	if len(id) > 128 {
 		id = id[:128]
 	}
+	// Fast path: most trace IDs (UUIDs, hex) are already clean.
+	// Scan first to avoid strings.Builder allocation.
+	clean := true
+	for i := 0; i < len(id); i++ {
+		if id[i] < 0x20 || id[i] > 0x7E {
+			clean = false
+			break
+		}
+	}
+	if clean {
+		return id
+	}
+	// Slow path: sanitize dirty input.
 	var b strings.Builder
 	b.Grow(len(id))
 	for i := 0; i < len(id); i++ {


### PR DESCRIPTION
## Summary
- Adds a pre-scan loop in validateTraceID that checks if all bytes are already printable ASCII
- If clean (the common case for UUIDs/hex trace IDs), returns the string directly without allocating a strings.Builder

## Test plan
- [x] go test -race ./... passes
- [x] make lint — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized trace ID validation performance by adding a fast path for clean input, reducing unnecessary memory allocations in common cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->