### PR TITLE
feat: add goleak, guard InitRollbar on empty token

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-coldbrew/errors
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/airbrake/gobrake/v5 v5.6.2

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	go.uber.org/goleak v1.3.0
 	google.golang.org/grpc v1.79.3
 )
 

--- a/goleak_test.go
+++ b/goleak_test.go
@@ -1,0 +1,11 @@
+package errors
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -133,6 +133,9 @@ func InitAirbrake(projectID int64, projectKey string) {
 // token: rollbar token
 // env: rollbar environment
 func InitRollbar(token, env string) {
+	if token == "" {
+		return
+	}
 	rollbar.SetToken(token)
 	rollbar.SetEnvironment(env)
 	rollbar.SetStackTracer(func(err error) ([]runtime.Frame, bool) {

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -134,6 +134,7 @@ func InitAirbrake(projectID int64, projectKey string) {
 // env: rollbar environment
 func InitRollbar(token, env string) {
 	if token == "" {
+		rollbarInited = false
 		return
 	}
 	rollbar.SetToken(token)


### PR DESCRIPTION
## Summary
- Add `goleak.VerifyTestMain` to catch goroutine leaks in tests
- Guard `InitRollbar()` with early return when token is empty, preventing `rollbarInited=true` with no token configured

## Test plan
- [x] `make test` passes with goleak enabled
- [x] `make lint` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notification service now safely skips external error-reporting initialization when credentials are missing.

* **Chores**
  * Added goroutine leak detection to the test suite to catch concurrency issues.
  * Updated build toolchain declaration and bumped an internal test dependency for improved testing stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->