### PR TITLE
fix(notifier): migrate Sentry Event.Extra to Contexts for sentry-go v0.46

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.9
 
 require (
 	github.com/airbrake/gobrake/v5 v5.6.2
-	github.com/getsentry/sentry-go v0.43.0
+	github.com/getsentry/sentry-go v0.46.2
 	github.com/go-coldbrew/log v0.3.0
 	github.com/go-coldbrew/options v0.3.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -215,8 +215,8 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/fzipp/gocyclo v0.6.0 h1:lsblElZG7d3ALtGMx9fmxeTKZaLLpU8mET09yN4BBLo=
 github.com/fzipp/gocyclo v0.6.0/go.mod h1:rXPyn8fnlpa0R2csP/31uerbiVBugk5whMdlyaLkLoA=
-github.com/getsentry/sentry-go v0.43.0 h1:XbXLpFicpo8HmBDaInk7dum18G9KSLcjZiyUKS+hLW4=
-github.com/getsentry/sentry-go v0.43.0/go.mod h1:XDotiNZbgf5U8bPDUAfvcFmOnMQQceESxyKaObSssW0=
+github.com/getsentry/sentry-go v0.46.2 h1:1jhYwrKGa3sIpo/y5iDNXS5wDoT7I1KNzMHrnK6ojns=
+github.com/getsentry/sentry-go v0.46.2/go.mod h1:evVbw2qotNUdYG8KxXbAdjOQWWvWIwKxpjdZZIvcIPw=
 github.com/ghostiam/protogetter v0.3.20 h1:oW7OPFit2FxZOpmMRPP9FffU4uUpfeE/rEdE1f+MzD0=
 github.com/ghostiam/protogetter v0.3.20/go.mod h1:FjIu5Yfs6FT391m+Fjp3fbAYJ6rkL/J6ySpZBfnODuI=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -295,7 +295,6 @@ func buildSentryEvent(err errors.ErrorExt, level string, extra map[string]interf
 		Level:       sentryLevel,
 		Environment: sentryEnvironment,
 		Release:     sentryRelease,
-		Extra:       extra,
 		Exception: []sentry.Exception{
 			{
 				Type:       reflect.TypeOf(err).String(),
@@ -303,6 +302,10 @@ func buildSentryEvent(err errors.ErrorExt, level string, extra map[string]interf
 				Stacktrace: convToSentry(err),
 			},
 		},
+	}
+
+	if len(extra) > 0 {
+		event.Contexts = map[string]sentry.Context{"extra": extra}
 	}
 
 	if len(tagData) > 0 {

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -305,7 +305,10 @@ func buildSentryEvent(err errors.ErrorExt, level string, extra map[string]interf
 	}
 
 	if len(extra) > 0 {
-		event.Contexts = map[string]sentry.Context{"extra": extra}
+		if event.Contexts == nil {
+			event.Contexts = make(map[string]sentry.Context)
+		}
+		event.Contexts["extra"] = extra
 	}
 
 	if len(tagData) > 0 {

--- a/notifier/notifier_sentry_test.go
+++ b/notifier/notifier_sentry_test.go
@@ -179,8 +179,8 @@ func TestSentryExtra(t *testing.T) {
 	if event == nil {
 		t.Fatal("expected captured event")
 	}
-	if len(event.Extra) == 0 {
-		t.Error("expected non-empty Extra on event")
+	if len(event.Contexts["extra"]) == 0 {
+		t.Error("expected non-empty extra context on event")
 	}
 }
 
@@ -226,8 +226,8 @@ func TestBuildSentryEvent(t *testing.T) {
 	if event.Message != "build event test" {
 		t.Errorf("expected message 'build event test', got %v", event.Message)
 	}
-	if event.Extra["key"] != "value" {
-		t.Errorf("expected extra key=value, got %v", event.Extra["key"])
+	if event.Contexts["extra"]["key"] != "value" {
+		t.Errorf("expected extra key=value, got %v", event.Contexts["extra"]["key"])
 	}
 	if event.Tags["tag1"] != "val1" {
 		t.Errorf("expected tag tag1=val1, got %v", event.Tags["tag1"])


### PR DESCRIPTION
## Summary
- `sentry-go` v0.46 removed `Event.Extra`. Downstream consumers that pull v0.46+ transitively fail to compile against `errors v0.2.15` with `unknown field Extra in struct literal of type sentry.Event`.
- Migrate the extra payload to `event.Contexts["extra"]` (`sentry.Context` is a `map[string]interface{}` alias, so the shape is preserved) and only set it when non-empty.
- Bump `github.com/getsentry/sentry-go` from v0.43.0 to v0.46.2.

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./...`
- [x] `make lint` (golangci-lint + govulncheck)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Sentry error tracking dependency to the latest version.
  * Adjusted how event metadata is structured to align with updated Sentry library requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->